### PR TITLE
Fix EventBus.register method. In production mode only class literals can be created by GWT.create.

### DIFF
--- a/supereventbus/src/main/java/com/ekuefler/supereventbus/EventBus.java
+++ b/supereventbus/src/main/java/com/ekuefler/supereventbus/EventBus.java
@@ -249,11 +249,9 @@ public class EventBus {
    * invoked with that event.
    *
    * @param owner object to scan for {@link Subscribe}-annotated methods to register
-   * @param registrationClass the class object of a registration interface for the given owner
+   * @param registration the registration interface for the given owner
    */
-  public <T> void register(T owner, Class<? extends EventRegistration<T>> registrationClass) {
-    EventRegistration<T> registration = GWT.create(registrationClass);
-
+  public <T> void register(T owner, EventRegistration<T> registration) {
     // Add each handler method in the class to the global handler map according to its priority. The
     // cache mapping event classes to handler methods will be updated when an event is fired.
     for (EventHandlerMethod<T, ?> method : registration.getMethods()) {

--- a/supereventbus/src/test/java/com/ekuefler/supereventbus/BasicTest.java
+++ b/supereventbus/src/test/java/com/ekuefler/supereventbus/BasicTest.java
@@ -13,8 +13,7 @@
  */
 package com.ekuefler.supereventbus;
 
-import com.ekuefler.supereventbus.EventRegistration;
-import com.ekuefler.supereventbus.Subscribe;
+import com.google.gwt.core.client.GWT;
 
 import java.util.List;
 
@@ -62,7 +61,7 @@ public class BasicTest extends SuperEventBusTestCase {
   protected void gwtSetUp() throws Exception {
     super.gwtSetUp();
     owner = new TestOwner();
-    eventBus.register(owner, MyRegistration.class);
+    eventBus.register(owner, (MyRegistration) GWT.create(MyRegistration.class));
   }
 
   public void testShouldDispatchObjects() {

--- a/supereventbus/src/test/java/com/ekuefler/supereventbus/CacheTest.java
+++ b/supereventbus/src/test/java/com/ekuefler/supereventbus/CacheTest.java
@@ -13,8 +13,7 @@
  */
 package com.ekuefler.supereventbus;
 
-import com.ekuefler.supereventbus.EventRegistration;
-import com.ekuefler.supereventbus.Subscribe;
+import com.google.gwt.core.client.GWT;
 
 public class CacheTest extends SuperEventBusTestCase {
 
@@ -33,9 +32,9 @@ public class CacheTest extends SuperEventBusTestCase {
     TestOwner owner1 = new TestOwner();
     TestOwner owner2 = new TestOwner();
 
-    eventBus.register(owner1, TestOwner.MyRegistration.class);
+    eventBus.register(owner1, (TestOwner.MyRegistration) GWT.create(TestOwner.MyRegistration.class));
     eventBus.post("string");
-    eventBus.register(owner2, TestOwner.MyRegistration.class);
+    eventBus.register(owner2, (TestOwner.MyRegistration) GWT.create(TestOwner.MyRegistration.class));
     eventBus.post("string");
 
     assertEquals(2, owner1.eventsHandled);
@@ -45,10 +44,10 @@ public class CacheTest extends SuperEventBusTestCase {
   public void testShouldBeAbleToReRegisterHandlersAfterEventsAreFired() {
     TestOwner owner = new TestOwner();
 
-    eventBus.register(owner, TestOwner.MyRegistration.class);
+    eventBus.register(owner, (TestOwner.MyRegistration) GWT.create(TestOwner.MyRegistration.class));
     eventBus.post("string");
     eventBus.unregister(owner);
-    eventBus.register(owner, TestOwner.MyRegistration.class);
+    eventBus.register(owner, (TestOwner.MyRegistration) GWT.create(TestOwner.MyRegistration.class));
     eventBus.post("string");
 
     assertEquals(2, owner.eventsHandled);
@@ -57,12 +56,12 @@ public class CacheTest extends SuperEventBusTestCase {
   public void testShouldBeAbleToReRegisterHandlersBeforeEventsAreFired() {
     TestOwner owner1 = new TestOwner();
     TestOwner owner2 = new TestOwner();
-    eventBus.register(owner1, TestOwner.MyRegistration.class);
+    eventBus.register(owner1, (TestOwner.MyRegistration) GWT.create(TestOwner.MyRegistration.class));
     eventBus.post("string");
 
-    eventBus.register(owner2, TestOwner.MyRegistration.class);
+    eventBus.register(owner2, (TestOwner.MyRegistration) GWT.create(TestOwner.MyRegistration.class));
     eventBus.unregister(owner2);
-    eventBus.register(owner2, TestOwner.MyRegistration.class);
+    eventBus.register(owner2, (TestOwner.MyRegistration) GWT.create(TestOwner.MyRegistration.class));
     eventBus.post("string");
 
     assertEquals(2, owner1.eventsHandled);

--- a/supereventbus/src/test/java/com/ekuefler/supereventbus/DeadEventTest.java
+++ b/supereventbus/src/test/java/com/ekuefler/supereventbus/DeadEventTest.java
@@ -13,12 +13,10 @@
  */
 package com.ekuefler.supereventbus;
 
-import com.ekuefler.supereventbus.DeadEvent;
-import com.ekuefler.supereventbus.EventRegistration;
-import com.ekuefler.supereventbus.Subscribe;
 import com.ekuefler.supereventbus.DeadEventTest.TestOwner.MyRegistration;
 import com.ekuefler.supereventbus.filtering.EventFilter;
 import com.ekuefler.supereventbus.filtering.When;
+import com.google.gwt.core.client.GWT;
 
 public class DeadEventTest extends SuperEventBusTestCase {
 
@@ -53,7 +51,7 @@ public class DeadEventTest extends SuperEventBusTestCase {
   protected void gwtSetUp() throws Exception {
     super.gwtSetUp();
     owner = new TestOwner();
-    eventBus.register(owner, MyRegistration.class);
+    eventBus.register(owner, (MyRegistration) GWT.create(MyRegistration.class));
   }
 
   public void testShouldFireDeadEventForEventWithoutHandlers() throws Exception {

--- a/supereventbus/src/test/java/com/ekuefler/supereventbus/EventBusAdapterTest.java
+++ b/supereventbus/src/test/java/com/ekuefler/supereventbus/EventBusAdapterTest.java
@@ -13,10 +13,8 @@
  */
 package com.ekuefler.supereventbus;
 
-import com.ekuefler.supereventbus.EventBusAdapter;
-import com.ekuefler.supereventbus.EventRegistration;
-import com.ekuefler.supereventbus.Subscribe;
 import com.ekuefler.supereventbus.EventBusAdapterTest.TestOwner.MyRegistration;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.web.bindery.event.shared.HandlerRegistration;
@@ -48,7 +46,7 @@ public class EventBusAdapterTest extends SuperEventBusTestCase {
   }
 
   public void testFireOnAdapterShouldReceiveOnReal() {
-    eventBus.register(owner, MyRegistration.class);
+    eventBus.register(owner, (MyRegistration) GWT.create(MyRegistration.class));
     adapter.fireEvent(new ClickEvent() {});
 
     assertNotNull(owner.event);

--- a/supereventbus/src/test/java/com/ekuefler/supereventbus/ExceptionTest.java
+++ b/supereventbus/src/test/java/com/ekuefler/supereventbus/ExceptionTest.java
@@ -13,10 +13,7 @@
  */
 package com.ekuefler.supereventbus;
 
-import com.ekuefler.supereventbus.EventBusException;
-import com.ekuefler.supereventbus.EventRegistration;
-import com.ekuefler.supereventbus.ExceptionHandler;
-import com.ekuefler.supereventbus.Subscribe;
+import com.google.gwt.core.client.GWT;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -52,7 +49,7 @@ public class ExceptionTest extends SuperEventBusTestCase {
   protected void gwtSetUp() throws Exception {
     super.gwtSetUp();
     owner = new TestOwner();
-    eventBus.register(owner, MyRegistration.class);
+    eventBus.register(owner, (MyRegistration) GWT.create(MyRegistration.class));
   }
 
   public void testShouldNotAllowPostingNulls() {

--- a/supereventbus/src/test/java/com/ekuefler/supereventbus/FilteringTest.java
+++ b/supereventbus/src/test/java/com/ekuefler/supereventbus/FilteringTest.java
@@ -13,10 +13,9 @@
  */
 package com.ekuefler.supereventbus;
 
-import com.ekuefler.supereventbus.EventRegistration;
-import com.ekuefler.supereventbus.Subscribe;
 import com.ekuefler.supereventbus.filtering.EventFilter;
 import com.ekuefler.supereventbus.filtering.When;
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.ui.HasVisibility;
 
 import java.util.LinkedList;
@@ -88,7 +87,7 @@ public class FilteringTest extends SuperEventBusTestCase {
   protected void gwtSetUp() throws Exception {
     super.gwtSetUp();
     owner = new TestOwner();
-    eventBus.register(owner, TestOwner.MyRegistration.class);
+    eventBus.register(owner, (TestOwner.MyRegistration) GWT.create(TestOwner.MyRegistration.class));
   }
 
   public void testShouldApplySingleFilter() {

--- a/supereventbus/src/test/java/com/ekuefler/supereventbus/MultiEventTest.java
+++ b/supereventbus/src/test/java/com/ekuefler/supereventbus/MultiEventTest.java
@@ -13,10 +13,9 @@
  */
 package com.ekuefler.supereventbus;
 
-import com.ekuefler.supereventbus.EventRegistration;
-import com.ekuefler.supereventbus.Subscribe;
 import com.ekuefler.supereventbus.multievent.EventTypes;
 import com.ekuefler.supereventbus.multievent.MultiEvent;
+import com.google.gwt.core.client.GWT;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -46,7 +45,7 @@ public class MultiEventTest extends SuperEventBusTestCase {
   protected void gwtSetUp() throws Exception {
     super.gwtSetUp();
     owner = new TestOwner();
-    eventBus.register(owner, MyRegistration.class);
+    eventBus.register(owner, (MyRegistration) GWT.create(MyRegistration.class));
   }
 
   public void testShouldReceiveManyEventTypes() {

--- a/supereventbus/src/test/java/com/ekuefler/supereventbus/OrderingTest.java
+++ b/supereventbus/src/test/java/com/ekuefler/supereventbus/OrderingTest.java
@@ -13,8 +13,7 @@
  */
 package com.ekuefler.supereventbus;
 
-import com.ekuefler.supereventbus.EventRegistration;
-import com.ekuefler.supereventbus.Subscribe;
+import com.google.gwt.core.client.GWT;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -52,7 +51,7 @@ public class OrderingTest extends SuperEventBusTestCase {
   protected void gwtSetUp() throws Exception {
     super.gwtSetUp();
     owner = new TestOwner();
-    eventBus.register(owner, MyRegistration.class);
+    eventBus.register(owner, (MyRegistration) GWT.create(MyRegistration.class));
   }
 
   public void testEventOrdering() {

--- a/supereventbus/src/test/java/com/ekuefler/supereventbus/PolymorphismTest.java
+++ b/supereventbus/src/test/java/com/ekuefler/supereventbus/PolymorphismTest.java
@@ -13,8 +13,7 @@
  */
 package com.ekuefler.supereventbus;
 
-import com.ekuefler.supereventbus.EventRegistration;
-import com.ekuefler.supereventbus.Subscribe;
+import com.google.gwt.core.client.GWT;
 
 import java.util.AbstractSequentialList;
 import java.util.ArrayList;
@@ -58,7 +57,7 @@ public class PolymorphismTest extends SuperEventBusTestCase {
   protected void gwtSetUp() throws Exception {
     super.gwtSetUp();
     owner = new TestOwner();
-    eventBus.register(owner, TestOwner.MyRegistration.class);
+    eventBus.register(owner, (TestOwner.MyRegistration) GWT.create(TestOwner.MyRegistration.class));
   }
 
   public void testShouldHandleObjects() {

--- a/supereventbus/src/test/java/com/ekuefler/supereventbus/PriorityTest.java
+++ b/supereventbus/src/test/java/com/ekuefler/supereventbus/PriorityTest.java
@@ -16,9 +16,8 @@ package com.ekuefler.supereventbus;
 import java.util.LinkedList;
 import java.util.List;
 
-import com.ekuefler.supereventbus.EventRegistration;
-import com.ekuefler.supereventbus.Subscribe;
 import com.ekuefler.supereventbus.priority.WithPriority;
+import com.google.gwt.core.client.GWT;
 
 public class PriorityTest extends SuperEventBusTestCase {
 
@@ -63,7 +62,7 @@ public class PriorityTest extends SuperEventBusTestCase {
   protected void gwtSetUp() throws Exception {
     super.gwtSetUp();
     owner = new TestOwner();
-    eventBus.register(owner, TestOwner.MyRegistration.class);
+    eventBus.register(owner, (TestOwner.MyRegistration) GWT.create(TestOwner.MyRegistration.class));
   }
 
   public void testShouldHandleInPriorityOrder() {


### PR DESCRIPTION
GWT compiler was complaining about the call of GWT.create with a class variable in EventBus.register method.
It's easy to forget but javadoc is clear:
[GWT.create(java.lang.Class<?> classLiteral)](http://www.gwtproject.org/javadoc/latest/com/google/gwt/core/client/GWT.html#create%28java.lang.Class%29)

> The argument to create(Class) must be a class literal because the Production Mode compiler must be able to statically determine the requested type at compile-time. This can be tricky because using a Class variable may appear to work correctly in Development Mode.

I see no other solution than having to externalize the GWT.create, developer has to instantiate himself the EventRegistration interface and pass it to the EventBus.register, as usual.

I changed all unit tests, they are all passing.
